### PR TITLE
Safely scope workers in demo implementation.

### DIFF
--- a/GrasshopperAsyncComponentDemo/SampleImplementations/Sample_PrimeCalculatorAsyncComponent.cs
+++ b/GrasshopperAsyncComponentDemo/SampleImplementations/Sample_PrimeCalculatorAsyncComponent.cs
@@ -10,107 +10,106 @@ using System.Windows.Forms;
 
 namespace GrasshopperAsyncComponentDemo.SampleImplementations
 {
-  public class Sample_PrimeCalculatorAsyncComponent : GH_AsyncComponent
-  {
-    public override Guid ComponentGuid { get => new Guid("22C612B0-2C57-47CE-B9FE-E10621F18933"); }
-
-    protected override System.Drawing.Bitmap Icon { get => Properties.Resources.logo32; }
-
-    public override GH_Exposure Exposure => GH_Exposure.primary;
-
-    public Sample_PrimeCalculatorAsyncComponent() : base("The N-th Prime Calculator", "PRIME", "Calculates the nth prime number.", "Samples", "Async")
+    public class Sample_PrimeCalculatorAsyncComponent : GH_AsyncComponent
     {
-      BaseWorker = new PrimeCalculatorWorker();
-    }
+        public override Guid ComponentGuid { get => new Guid("22C612B0-2C57-47CE-B9FE-E10621F18933"); }
 
-    protected override void RegisterInputParams(GH_InputParamManager pManager)
-    {
-      pManager.AddIntegerParameter("N", "N", "Which n-th prime number. Minimum 1, maximum one million. Take care, it can burn your CPU.", GH_ParamAccess.item);
-    }
+        protected override System.Drawing.Bitmap Icon { get => Properties.Resources.logo32; }
 
-    protected override void RegisterOutputParams(GH_OutputParamManager pManager)
-    {
-      pManager.AddNumberParameter("Output", "O", "The n-th prime number.", GH_ParamAccess.item);
-    }
+        public override GH_Exposure Exposure => GH_Exposure.primary;
 
-    public override void AppendAdditionalMenuItems(ToolStripDropDown menu)
-    {
-      base.AppendAdditionalMenuItems(menu);
-      Menu_AppendItem(menu, "Cancel", (s, e) =>
-      {
-        RequestCancellation();
-      });
-    }
-  }
-
-  public class PrimeCalculatorWorker : WorkerInstance
-  {
-    int TheNthPrime { get; set; } = 100;
-    long ThePrime { get; set; } = -1;
-
-    public PrimeCalculatorWorker() : base(null) { }
-
-    public override void DoWork(Action<string, double> ReportProgress, Action Done)
-    {
-      // 👉 Checking for cancellation!
-      if (CancellationToken.IsCancellationRequested) { return; }
-
-      int count = 0;
-      long a = 2;
-
-      // Thanks Steak Overflow (TM) https://stackoverflow.com/a/13001749/
-      while (count < TheNthPrime)
-      {
-        // 👉 Checking for cancellation!
-        if (CancellationToken.IsCancellationRequested) {  return; }
-
-        long b = 2;
-        int prime = 1;// to check if found a prime
-        while (b * b <= a)
+        public Sample_PrimeCalculatorAsyncComponent() : base("The N-th Prime Calculator", "PRIME", "Calculates the nth prime number.", "Samples", "Async")
         {
-          // 👉 Checking for cancellation!
-          if (CancellationToken.IsCancellationRequested) {return; }
-
-          if (a % b == 0)
-          {
-            prime = 0;
-            break;
-          }
-          b++;
+            BaseWorker = new PrimeCalculatorWorker();
         }
 
-        ReportProgress(Id, ((double)count) / TheNthPrime);
-
-        if (prime > 0)
+        protected override void RegisterInputParams(GH_InputParamManager pManager)
         {
-          count++;
+            pManager.AddIntegerParameter("N", "N", "Which n-th prime number. Minimum 1, maximum one million. Take care, it can burn your CPU.", GH_ParamAccess.item);
         }
-        a++;
-      }
 
-      ThePrime = --a;
-      Done();
+        protected override void RegisterOutputParams(GH_OutputParamManager pManager)
+        {
+            pManager.AddNumberParameter("Output", "O", "The n-th prime number.", GH_ParamAccess.item);
+        }
+
+        public override void AppendAdditionalMenuItems(ToolStripDropDown menu)
+        {
+            base.AppendAdditionalMenuItems(menu);
+            Menu_AppendItem(menu, "Cancel", (s, e) =>
+            {
+                RequestCancellation();
+            });
+        }
+
+        private class PrimeCalculatorWorker : WorkerInstance
+        {
+            int TheNthPrime { get; set; } = 100;
+            long ThePrime { get; set; } = -1;
+
+            public PrimeCalculatorWorker() : base(null) { }
+
+            public override void DoWork(Action<string, double> ReportProgress, Action Done)
+            {
+                // 👉 Checking for cancellation!
+                if (CancellationToken.IsCancellationRequested) { return; }
+
+                int count = 0;
+                long a = 2;
+
+                // Thanks Steak Overflow (TM) https://stackoverflow.com/a/13001749/
+                while (count < TheNthPrime)
+                {
+                    // 👉 Checking for cancellation!
+                    if (CancellationToken.IsCancellationRequested) { return; }
+
+                    long b = 2;
+                    int prime = 1;// to check if found a prime
+                    while (b * b <= a)
+                    {
+                        // 👉 Checking for cancellation!
+                        if (CancellationToken.IsCancellationRequested) { return; }
+
+                        if (a % b == 0)
+                        {
+                            prime = 0;
+                            break;
+                        }
+                        b++;
+                    }
+
+                    ReportProgress(Id, ((double)count) / TheNthPrime);
+
+                    if (prime > 0)
+                    {
+                        count++;
+                    }
+                    a++;
+                }
+
+                ThePrime = --a;
+                Done();
+            }
+
+            public override WorkerInstance Duplicate() => new PrimeCalculatorWorker();
+
+            public override void GetData(IGH_DataAccess DA, GH_ComponentParamServer Params)
+            {
+                int _nthPrime = 100;
+                DA.GetData(0, ref _nthPrime);
+                if (_nthPrime > 1000000) _nthPrime = 1000000;
+                if (_nthPrime < 1) _nthPrime = 1;
+
+                TheNthPrime = _nthPrime;
+            }
+
+            public override void SetData(IGH_DataAccess DA)
+            {
+                // 👉 Checking for cancellation!
+                if (CancellationToken.IsCancellationRequested) { return; }
+
+                DA.SetData(0, ThePrime);
+            }
+        }
     }
-
-    public override WorkerInstance Duplicate() => new PrimeCalculatorWorker();
-
-    public override void GetData(IGH_DataAccess DA, GH_ComponentParamServer Params)
-    {
-      int _nthPrime = 100;
-      DA.GetData(0, ref _nthPrime);
-      if (_nthPrime > 1000000) _nthPrime = 1000000;
-      if (_nthPrime < 1) _nthPrime = 1;
-
-      TheNthPrime = _nthPrime;
-    }
-
-    public override void SetData(IGH_DataAccess DA)
-    {
-      // 👉 Checking for cancellation!
-      if (CancellationToken.IsCancellationRequested) { return; }
-
-      DA.SetData(0, ThePrime);
-    }
-  }
-
 }

--- a/GrasshopperAsyncComponentDemo/SampleImplementations/Sample_UslessCyclesComponent.cs
+++ b/GrasshopperAsyncComponentDemo/SampleImplementations/Sample_UslessCyclesComponent.cs
@@ -10,84 +10,83 @@ using System.Windows.Forms;
 
 namespace GrasshopperAsyncComponentDemo.SampleImplementations
 {
-  public class Sample_UselessCyclesAsyncComponent : GH_AsyncComponent
-  {
-    public override Guid ComponentGuid { get => new Guid("DF2B93E2-052D-4BE4-BC62-90DC1F169BF6"); }
-
-    protected override System.Drawing.Bitmap Icon { get => Properties.Resources.logo32; }
-
-    public override GH_Exposure Exposure => GH_Exposure.primary;
-
-    public Sample_UselessCyclesAsyncComponent() : base("Sample Async Component", "CYCLOMATRON-X", "Spins uselessly.", "Samples", "Async")
+    public class Sample_UselessCyclesAsyncComponent : GH_AsyncComponent
     {
-      BaseWorker = new UselessCyclesWorker();
+        public override Guid ComponentGuid { get => new Guid("DF2B93E2-052D-4BE4-BC62-90DC1F169BF6"); }
+
+        protected override System.Drawing.Bitmap Icon { get => Properties.Resources.logo32; }
+
+        public override GH_Exposure Exposure => GH_Exposure.primary;
+
+        public Sample_UselessCyclesAsyncComponent() : base("Sample Async Component", "CYCLOMATRON-X", "Spins uselessly.", "Samples", "Async")
+        {
+            BaseWorker = new UselessCyclesWorker();
+        }
+
+        private class UselessCyclesWorker : WorkerInstance
+        {
+            int MaxIterations { get; set; } = 100;
+
+            public UselessCyclesWorker() : base(null) { }
+
+            public override void DoWork(Action<string, double> ReportProgress, Action Done)
+            {
+                // Checking for cancellation
+                if (CancellationToken.IsCancellationRequested) { return; }
+
+                for (int i = 0; i <= MaxIterations; i++)
+                {
+                    var sw = new SpinWait();
+                    for (int j = 0; j <= 100; j++)
+                        sw.SpinOnce();
+
+                    ReportProgress(Id, ((double)(i + 1) / (double)MaxIterations));
+
+                    // Checking for cancellation
+                    if (CancellationToken.IsCancellationRequested) { return; }
+                }
+
+                Done();
+            }
+
+            public override WorkerInstance Duplicate() => new UselessCyclesWorker();
+
+            public override void GetData(IGH_DataAccess DA, GH_ComponentParamServer Params)
+            {
+                if (CancellationToken.IsCancellationRequested) return;
+
+                int _maxIterations = 100;
+                DA.GetData(0, ref _maxIterations);
+                if (_maxIterations > 1000) _maxIterations = 1000;
+                if (_maxIterations < 10) _maxIterations = 10;
+
+                MaxIterations = _maxIterations;
+            }
+
+            public override void SetData(IGH_DataAccess DA)
+            {
+                if (CancellationToken.IsCancellationRequested) return;
+                DA.SetData(0, $"Hello world. Worker {Id} has spun for {MaxIterations} iterations.");
+            }
+        }
+
+        protected override void RegisterInputParams(GH_InputParamManager pManager)
+        {
+            pManager.AddIntegerParameter("N", "N", "Number of spins.", GH_ParamAccess.item);
+        }
+
+        protected override void RegisterOutputParams(GH_OutputParamManager pManager)
+        {
+            pManager.AddTextParameter("Output", "O", "Nothing really interesting.", GH_ParamAccess.item);
+        }
+
+        public override void AppendAdditionalMenuItems(ToolStripDropDown menu)
+        {
+            base.AppendAdditionalMenuItems(menu);
+            Menu_AppendItem(menu, "Cancel", (s, e) =>
+            {
+                RequestCancellation();
+            });
+        }
     }
-
-    protected override void RegisterInputParams(GH_InputParamManager pManager)
-    {
-      pManager.AddIntegerParameter("N", "N", "Number of spins.", GH_ParamAccess.item);
-    }
-
-    protected override void RegisterOutputParams(GH_OutputParamManager pManager)
-    {
-      pManager.AddTextParameter("Output", "O", "Nothing really interesting.", GH_ParamAccess.item);
-    }
-
-    public override void AppendAdditionalMenuItems(ToolStripDropDown menu)
-    {
-      base.AppendAdditionalMenuItems(menu);
-      Menu_AppendItem(menu, "Cancel", (s, e) =>
-      {
-        RequestCancellation();
-      });
-    }
-  }
-
-  public class UselessCyclesWorker : WorkerInstance
-  {
-    int MaxIterations { get; set; } = 100;
-
-    public UselessCyclesWorker() : base(null) { }
-
-    public override void DoWork(Action<string, double> ReportProgress, Action Done)
-    {
-      // Checking for cancellation
-      if (CancellationToken.IsCancellationRequested) { return; }
-
-      for (int i = 0; i <= MaxIterations; i++)
-      {
-        var sw = new SpinWait();
-        for (int j = 0; j <= 100; j++)
-          sw.SpinOnce();
-
-        ReportProgress(Id, ((double)(i + 1) / (double)MaxIterations));
-
-        // Checking for cancellation
-        if (CancellationToken.IsCancellationRequested) { return; }
-      }
-
-      Done();
-    }
-
-    public override WorkerInstance Duplicate() => new UselessCyclesWorker();
-
-    public override void GetData(IGH_DataAccess DA, GH_ComponentParamServer Params)
-    {
-      if (CancellationToken.IsCancellationRequested) return;
-
-      int _maxIterations = 100;
-      DA.GetData(0, ref _maxIterations);
-      if (_maxIterations > 1000) _maxIterations = 1000;
-      if (_maxIterations < 10) _maxIterations = 10;
-
-      MaxIterations = _maxIterations;
-    }
-
-    public override void SetData(IGH_DataAccess DA)
-    {
-      if (CancellationToken.IsCancellationRequested) return;
-      DA.SetData(0, $"Hello world. Worker {Id} has spun for {MaxIterations} iterations.");
-    }
-  }
-
 }


### PR DESCRIPTION
Not specifically an improvement to the base, but rather to the demo files. Found that it was relatively easy to make the mistake, but frustrating to find out exactly what happened when implementing the first few inherited components, as instances from one were publicly available to others. When Sascha made the same mistakes, we decided to fix it and thought it would be worth doing here too.