### PR TITLE
feat(ci): Add Assembly version to published dlls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,18 +9,23 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Set version env var
+          command: |
+            $semver = if([string]::IsNullOrEmpty($env:CIRCLE_TAG)) { "0.0.999" } else { $env:CIRCLE_TAG }
+            $ver = if($semver.Contains('-')) {$semver.Split("-")[0] } else { $semver }
+            $version = "$($ver).$($env:WORKFLOW_NUM)"
+      - run:
           name: Restore packages
           command: nuget restore GrasshopperAsyncComponent.sln
       - run:
           name: Build solution
-          command: msbuild GrasshopperAsyncComponent.sln /p:Configuration=Release
+          command: msbuild GrasshopperAsyncComponent.sln /p:Configuration=Release /p:AssemblyVersionNumber=$version /p:AssemblyInformationalVersion=$semver /p:Version=$semver
       - run:
           name: Pack NuGet
           command: cd GrasshopperAsyncComponent; nuget pack GrasshopperAsyncComponent.csproj -Prop Configuration=Release -Symbols -SymbolPackageFormat snupkg
       - run:
           name: Push NuGet
           command: cd GrasshopperAsyncComponent; nuget push *.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey $env:NUGET_APIKEY -SkipDuplicate
-
 
 workflows:
   publish:
@@ -32,4 +37,3 @@ workflows:
             branches:
               ignore: /.*/
           context: nuget
-    

--- a/GrasshopperAsyncComponent/GrasshopperAsyncComponent.csproj
+++ b/GrasshopperAsyncComponent/GrasshopperAsyncComponent.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -55,6 +55,11 @@
     <PackageReference Include="RhinoCommon">
       <Version>6.28.20199.17141</Version>
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="MSBuild.AssemblyVersion">
+        <Version>1.3.0</Version>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/GrasshopperAsyncComponent/GrasshopperAsyncComponent.nuspec
+++ b/GrasshopperAsyncComponent/GrasshopperAsyncComponent.nuspec
@@ -2,7 +2,6 @@
 <package >
   <metadata>
     <id>GrasshopperAsyncComponent</id>
-    <version>1.2.3.0</version>
     <title>GrasshopperAsyncComponent</title>
     <authors>Speckle Systems</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/GrasshopperAsyncComponent/Properties/AssemblyInfo.cs
+++ b/GrasshopperAsyncComponent/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("GrasshopperAsyncComponent")]
@@ -13,8 +13,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
@@ -24,12 +24,13 @@ using System.Runtime.InteropServices;
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version
-//      Minor Version 
+//      Minor Version
 //      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the Build and Revision Numbers 
+// You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.2.3.0")]
 [assembly: AssemblyFileVersion("1.2.3.0")]
+[assembly: AssemblyInformationalVersion("1.2.3.0")]


### PR DESCRIPTION
Fixes #10 

Modified CI build to get it's version assigned based on the tag.

This is the same solution used in our connectors, based on the `MSBuild.AssemblyVersion` nuget.