### PR TITLE
CI: Adds build job for normal merge commits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,14 +7,13 @@ commands:
   
 jobs:
   build:
-    docker:
-      - image: mcr.microsoft.com/dotnet/sdk:6.0
+    executor: win/default
     steps:
       - checkout
       - run:
           name: Set version env var
           command: |
-            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "'0.0.999'-ci.$WORKFLOW_NUM"; fi;)
+            $tag = if([string]::IsNullOrEmpty($env:CIRCLE_TAG)) { "0.0.$($env:WORKFLOW_NUM)-ci" } else { $env:CIRCLE_TAG }
           environment:
             WORKFLOW_NUM: << pipeline.number >>
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
       - run:
           name: Set version env var
           command: |
-            $tag = if([string]::IsNullOrEmpty($env:CIRCLE_TAG)) { "0.0.$($env:WORKFLOW_NUM)-ci" } else { $env:CIRCLE_TAG }
+            $TAG = if([string]::IsNullOrEmpty($env:CIRCLE_TAG)) { "0.0.$($env:WORKFLOW_NUM)-ci" } else { $env:CIRCLE_TAG }
           environment:
             WORKFLOW_NUM: << pipeline.number >>
       - run:
@@ -19,7 +19,9 @@ jobs:
           command: dotnet restore GrasshopperAsyncComponent.sln
       - run:
           name: Build solution
-          command: dotnet build GrasshopperAsyncComponent.sln --no-restore -c Release /p:Version=$env:tag  /p:AssemblyVersionNumber=$env:tag /p:AssemblyInformationalVersion=$env:tag
+          command: |
+            $($TAG)
+            dotnet build GrasshopperAsyncComponent.sln --no-restore -c Release /p:Version=$TAG  /p:AssemblyVersionNumber=$TAG /p:AssemblyInformationalVersion=$TAG
   
   publish_nuget:
     executor: win/default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,8 @@
 ﻿version: 2.1
 
 orbs:
-  win: circleci/windows@2.2.0
+  win: circleci/windows@5.0.0
 
-commands:
-  
 jobs:
   build:
     executor: win/default
@@ -47,9 +45,11 @@ jobs:
           command: nuget push *.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey $env:NUGET_APIKEY -SkipDuplicate
 
 workflows:
-  publish:
+  build:
     jobs:
       - build
+  publish:
+    jobs:
       - publish_nuget:
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,24 @@ orbs:
   win: circleci/windows@2.2.0
 
 jobs:
+  build:
+    docker:
+      - image: mcr.microsoft.com/dotnet/sdk:6.0
+  steps:
+    - checkout
+    - run:
+        name: Set version env var
+        command: |
+          TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "'0.0.999'-ci.$WORKFLOW_NUM"; fi;)
+        environment:
+          WORKFLOW_NUM: << pipeline.number >>
+    - run:
+        name: Restore packages
+        command: dotnet restore restore GrasshopperAsyncComponent.sln
+    - run:
+        name: Build solution
+        command: dotnet build GrasshopperAsyncComponent.sln --no-restore -c Release /p:Version=$TAG
+  
   publish_nuget:
     executor: win/default
     steps:
@@ -11,9 +29,7 @@ jobs:
       - run:
           name: Set version env var
           command: |
-            $semver = if([string]::IsNullOrEmpty($env:CIRCLE_TAG)) { "0.0.999" } else { $env:CIRCLE_TAG }
-            $ver = if($semver.Contains('-')) {$semver.Split("-")[0] } else { $semver }
-            $version = "$($ver).$($env:WORKFLOW_NUM)"
+            $tag = if([string]::IsNullOrEmpty($env:CIRCLE_TAG)) { "0.0.999" } else { $env:CIRCLE_TAG }
           environment:
             WORKFLOW_NUM: << pipeline.number >>
       - run:
@@ -21,17 +37,18 @@ jobs:
           command: nuget restore GrasshopperAsyncComponent.sln
       - run:
           name: Build solution
-          command: msbuild GrasshopperAsyncComponent.sln /p:Configuration=Release /p:AssemblyVersionNumber=$version /p:AssemblyInformationalVersion=$semver /p:Version=$semver
+          command: msbuild GrasshopperAsyncComponent.sln /p:Configuration=Release /p:Version=$tag
       - run:
           name: Pack NuGet
-          command: cd GrasshopperAsyncComponent; nuget pack GrasshopperAsyncComponent.csproj -Prop Configuration=Release -Symbols -SymbolPackageFormat snupkg
+          command: nuget pack GrasshopperAsyncComponent/GrasshopperAsyncComponent.csproj -Prop Configuration=Release -Symbols -SymbolPackageFormat snupkg
       - run:
           name: Push NuGet
-          command: cd GrasshopperAsyncComponent; nuget push *.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey $env:NUGET_APIKEY -SkipDuplicate
+          command: nuget push *.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey $env:NUGET_APIKEY -SkipDuplicate
 
 workflows:
   publish:
     jobs:
+      - build
       - publish_nuget:
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,20 +9,15 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Set version env var
-          command: |
-            $TAG = if([string]::IsNullOrEmpty($env:CIRCLE_TAG)) { "0.0.$($env:WORKFLOW_NUM)-ci" } else { $env:CIRCLE_TAG }
-          environment:
-            WORKFLOW_NUM: << pipeline.number >>
-      - run:
           name: Restore packages
           command: dotnet restore GrasshopperAsyncComponent.sln
       - run:
           name: Build solution
           command: |
-            $($TAG)
+            $TAG = if([string]::IsNullOrEmpty($env:CIRCLE_TAG)) { "0.0.$($env:WORKFLOW_NUM)-ci" } else { $env:CIRCLE_TAG }
             dotnet build GrasshopperAsyncComponent.sln --no-restore -c Release /p:Version=$TAG  /p:AssemblyVersionNumber=$TAG /p:AssemblyInformationalVersion=$TAG
-  
+          environment:
+            WORKFLOW_NUM: << pipeline.number >>
   publish_nuget:
     executor: win/default
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
       - run:
           name: Set version env var
           command: |
-            $TAG = if([string]::IsNullOrEmpty($env:CIRCLE_TAG)) { "0.0.$($env:WORKFLOW_NUM)-ci" } else { $env:CIRCLE_TAG }
+            $tag = if([string]::IsNullOrEmpty($env:CIRCLE_TAG)) { "0.0.$($env:WORKFLOW_NUM)-ci" } else { $env:CIRCLE_TAG }
           environment:
             WORKFLOW_NUM: << pipeline.number >>
       - run:
@@ -19,7 +19,7 @@ jobs:
           command: dotnet restore GrasshopperAsyncComponent.sln
       - run:
           name: Build solution
-          command: dotnet build GrasshopperAsyncComponent.sln --no-restore -c Release /p:Version=$TAG  /p:AssemblyVersionNumber=$TAG /p:AssemblyInformationalVersion=$TAG
+          command: dotnet build GrasshopperAsyncComponent.sln --no-restore -c Release /p:Version=$env:tag  /p:AssemblyVersionNumber=$env:tag /p:AssemblyInformationalVersion=$env:tag
   
   publish_nuget:
     executor: win/default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
             WORKFLOW_NUM: << pipeline.number >>
       - run:
           name: Restore packages
-          command: dotnet restore restore GrasshopperAsyncComponent.sln
+          command: dotnet restore GrasshopperAsyncComponent.sln
       - run:
           name: Build solution
           command: dotnet build GrasshopperAsyncComponent.sln --no-restore -c Release /p:Version=$TAG

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
       - run:
           name: Build solution
           command: |
-            $TAG = if([string]::IsNullOrEmpty($env:CIRCLE_TAG)) { "0.0.$($env:WORKFLOW_NUM)-ci" } else { $env:CIRCLE_TAG }
+            $TAG = if([string]::IsNullOrEmpty($env:CIRCLE_TAG)) { "0.999.$($env:WORKFLOW_NUM)-ci" } else { $env:CIRCLE_TAG }
             dotnet build GrasshopperAsyncComponent.sln --no-restore -c Release /p:Version=$TAG  /p:AssemblyVersionNumber=$TAG /p:AssemblyInformationalVersion=$TAG
           environment:
             WORKFLOW_NUM: << pipeline.number >>
@@ -23,20 +23,15 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Set version env var
-          command: |
-            $tag = if([string]::IsNullOrEmpty($env:CIRCLE_TAG)) { "0.0.999" } else { $env:CIRCLE_TAG }
-          environment:
-            WORKFLOW_NUM: << pipeline.number >>
-      - run:
           name: Restore packages
-          command: nuget restore GrasshopperAsyncComponent.sln
+          command: dotnet restore GrasshopperAsyncComponent.sln
       - run:
           name: Build solution
-          command: msbuild GrasshopperAsyncComponent.sln /p:Configuration=Release /p:Version=$tag
-      - run:
-          name: Pack NuGet
-          command: nuget pack GrasshopperAsyncComponent/GrasshopperAsyncComponent.csproj -Prop Configuration=Release -Symbols -SymbolPackageFormat snupkg
+          command: |
+            $TAG = if([string]::IsNullOrEmpty($env:CIRCLE_TAG)) { "0.999.$($env:WORKFLOW_NUM)-ci" } else { $env:CIRCLE_TAG }
+            dotnet build GrasshopperAsyncComponent.sln --no-restore -c Release /p:Version=$TAG  /p:AssemblyVersionNumber=$TAG /p:AssemblyInformationalVersion=$TAG
+          environment:
+            WORKFLOW_NUM: << pipeline.number >>
       - run:
           name: Push NuGet
           command: nuget push *.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey $env:NUGET_APIKEY -SkipDuplicate
@@ -51,7 +46,7 @@ workflows:
       - publish_nuget:
           filters:
             tags:
-              only: /^v.*/
+              only: /.*/
             branches:
               ignore: /.*/
           context: nuget

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,14 +7,11 @@ jobs:
   build:
     executor: win/default
     steps:
-      - add_ssh_keys:
-          fingerprints:
-            - "62:b2:1a:86:b7:9f:83:91:9b:61:f8:52:66:38:78:64"
       - checkout
       - run:
           name: Set version env var
           command: |
-            $tag = if([string]::IsNullOrEmpty($env:CIRCLE_TAG)) { "0.0.$($env:WORKFLOW_NUM)-ci" } else { $env:CIRCLE_TAG }
+            $TAG = if([string]::IsNullOrEmpty($env:CIRCLE_TAG)) { "0.0.$($env:WORKFLOW_NUM)-ci" } else { $env:CIRCLE_TAG }
           environment:
             WORKFLOW_NUM: << pipeline.number >>
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,8 @@ jobs:
 workflows:
   build:
     jobs:
-      - build
+      - build:
+          context: github-dev-bot
   publish:
     jobs:
       - publish_nuget:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,9 @@ jobs:
   build:
     executor: win/default
     steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "62:b2:1a:86:b7:9f:83:91:9b:61:f8:52:66:38:78:64"
       - checkout
       - run:
           name: Set version env var

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
           command: dotnet restore GrasshopperAsyncComponent.sln
       - run:
           name: Build solution
-          command: dotnet build GrasshopperAsyncComponent.sln --no-restore -c Release /p:Version=$TAG
+          command: dotnet build GrasshopperAsyncComponent.sln --no-restore -c Release /p:Version=$TAG  /p:AssemblyVersionNumber=$TAG /p:AssemblyInformationalVersion=$TAG
   
   publish_nuget:
     executor: win/default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,24 +3,26 @@
 orbs:
   win: circleci/windows@2.2.0
 
+commands:
+  
 jobs:
   build:
     docker:
       - image: mcr.microsoft.com/dotnet/sdk:6.0
-  steps:
-    - checkout
-    - run:
-        name: Set version env var
-        command: |
-          TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "'0.0.999'-ci.$WORKFLOW_NUM"; fi;)
-        environment:
-          WORKFLOW_NUM: << pipeline.number >>
-    - run:
-        name: Restore packages
-        command: dotnet restore restore GrasshopperAsyncComponent.sln
-    - run:
-        name: Build solution
-        command: dotnet build GrasshopperAsyncComponent.sln --no-restore -c Release /p:Version=$TAG
+    steps:
+      - checkout
+      - run:
+          name: Set version env var
+          command: |
+            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "'0.0.999'-ci.$WORKFLOW_NUM"; fi;)
+          environment:
+            WORKFLOW_NUM: << pipeline.number >>
+      - run:
+          name: Restore packages
+          command: dotnet restore restore GrasshopperAsyncComponent.sln
+      - run:
+          name: Build solution
+          command: dotnet build GrasshopperAsyncComponent.sln --no-restore -c Release /p:Version=$TAG
   
   publish_nuget:
     executor: win/default

--- a/GrasshopperAsyncComponent/GrasshopperAsyncComponent.csproj
+++ b/GrasshopperAsyncComponent/GrasshopperAsyncComponent.csproj
@@ -21,6 +21,10 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/specklesystems/GrasshopperAsyncComponent</PackageProjectUrl>
     <PackageTags>grasshopper rhino mcneel gh_component</PackageTags>
+
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
Adds a `build` job to be run on normal commits, alongside the `publish_nuget` job that runs on every tag.

Tags will no longer be preceded by `v` (i.e. `v2.1.3` should now be `2.1.3`) and are supposed to follow SemVer conventions.